### PR TITLE
Fix VprLoader's PluginName and enhance after-build command

### DIFF
--- a/Intervallo.DefaultPlugins/Intervallo.DefaultPlugins.csproj
+++ b/Intervallo.DefaultPlugins/Intervallo.DefaultPlugins.csproj
@@ -108,7 +108,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) $(ProjectDir)..\Intervallo\bin\Debug\Plugins\</PostBuildEvent>
+    <PostBuildEvent>mkdir "$(ProjectDir)..\Intervallo\bin\Debug\Plugins\"
+copy "$(TargetPath)" "$(ProjectDir)..\Intervallo\bin\Debug\Plugins\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Intervallo.DefaultPlugins/VprLoader.cs
+++ b/Intervallo.DefaultPlugins/VprLoader.cs
@@ -25,7 +25,7 @@ namespace Intervallo.DefaultPlugins
 
         public string Description => LangResources.VprLoader_Description;
 
-        public string PluginName => typeof(VsqxLoader).Name;
+        public string PluginName => typeof(VprLoader).Name;
 
         public Version Version => new Version(((AssemblyVersionAttribute)typeof(WorldOperator).Assembly.GetCustomAttribute(typeof(AssemblyVersionAttribute))).Version);
 


### PR DESCRIPTION
Current after-build commands may have a chance to fail if the `Plugins` folder doesn't exist or the path contains spaces (e.g. `Documents\Visual Studio 2017\`).